### PR TITLE
Bump bal version to 2201.7.0 in release workflows

### DIFF
--- a/.github/workflows/dev-stg-release.yml
+++ b/.github/workflows/dev-stg-release.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Build Ballerina Project
       - name: Ballerina Build
-        uses: ballerina-platform/ballerina-action/@2201.2.1
+        uses: ballerina-platform/ballerina-action/@2201.7.0
         with:
           args:
             pack ./ballerina
@@ -56,7 +56,7 @@ jobs:
       # Push to Ballerina Staging Central
       - name: Push to Staging
         if: github.event.inputs.bal_central_environment == 'STAGE'
-        uses: ballerina-platform/ballerina-action/@2201.2.1
+        uses: ballerina-platform/ballerina-action/@2201.7.0
         with:
           args:
             push
@@ -68,7 +68,7 @@ jobs:
       # Push to Ballerina Dev Central
       - name: Push to Dev
         if: github.event.inputs.bal_central_environment == 'DEV'
-        uses: ballerina-platform/ballerina-action/@2201.2.1
+        uses: ballerina-platform/ballerina-action/@2201.7.0
         with:
           args:
             push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Build Ballerina Project
       - name: Ballerina Build
-        uses: ballerina-platform/ballerina-action/@2201.2.1
+        uses: ballerina-platform/ballerina-action/@2201.7.0
         with:
           args:
             pack ./ballerina
@@ -50,7 +50,7 @@ jobs:
 
       # Push to Ballerina Central
       - name: Ballerina Push
-        uses: ballerina-platform/ballerina-action/@2201.2.1
+        uses: ballerina-platform/ballerina-action/@2201.7.0
         with:
           args:
             push

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["IT Operations/Cloud Services", "Cost/Paid"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-cdata.connect"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.3.0"
+distribution = "2201.7.0"
 
 [[platform.java11.dependency]]
 path = "../native/build/libs/cdata.connect-native-1.2.0.jar"

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["IT Operations/Cloud Services", "Cost/Paid"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-cdata.connect"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.3.0"
+distribution = "2201.7.0"
 
 [[platform.java11.dependency]]
 path = "../native/build/libs/cdata.connect-native-@project.version@.jar"


### PR DESCRIPTION
# Description
- Update bal version as 2201.7.0 in release workflows

## Related issue
- https://github.com/wso2-enterprise/choreo/issues/22438